### PR TITLE
feat: Add chrome version as an optional parameter

### DIFF
--- a/chrome_extension_python/__init__.py
+++ b/chrome_extension_python/__init__.py
@@ -15,8 +15,7 @@ def relative_path(path, goback=0):
     return os.path.abspath(os.path.join(os.getcwd(), *levels, path.strip()))
 
 
-def download_and_unzip_chrome_extension(extension_id, download_dir):
-    chrome_version = "120.0.0.0"
+def download_and_unzip_chrome_extension(extension_id, download_dir, chrome_version):
     crx_url = f"https://clients2.google.com/service/update2/crx?response=redirect&prodversion={chrome_version}&x=id%3D{extension_id}%26installsource%3Dondemand%26uc&acceptformat=crx2,crx3"
 
     response = get(crx_url)
@@ -98,13 +97,15 @@ lock = Lock()
 class Extension:
     def __init__(
         self,
+        chrome_version = "120.0.0.0",
         extension_link=None,
         extension_id=None,
         extension_name=None,
         force_update=False,
-        
         **kwargs,
     ):
+        self.chrome_version = chrome_version
+
         self.extension_link = extension_link
         self.force_update = force_update
 
@@ -137,7 +138,7 @@ class Extension:
         print(f"Downloading {self.extension_name} Extension ...")
         create_extensions_directory_if_not_exists()
         download_and_unzip_chrome_extension(
-            self.extension_id, self.extension_absolute_path
+            self.extension_id, self.extension_absolute_path, self.chrome_version
         )
 
     def get_files(self, ext):

--- a/chrome_extension_python/__init__.py
+++ b/chrome_extension_python/__init__.py
@@ -97,11 +97,11 @@ lock = Lock()
 class Extension:
     def __init__(
         self,
-        chrome_version = "120.0.0.0",
         extension_link=None,
         extension_id=None,
         extension_name=None,
         force_update=False,
+        chrome_version = "120.0.0.0",
         **kwargs,
     ):
         self.chrome_version = chrome_version


### PR DESCRIPTION
Passing the Chrome version as an optional parameter, as mentioned in #3 
Example:  

```python
self.browser_options.add_argument(
    Extension(
        chrome_version="121.0.0.0",
        extension_id="xxxxxxxxxxxx",
        extension_name="example",
    ).load()
)
```

And without the Chrome version as well:  

```python
self.browser_options.add_argument(
    Extension(
        extension_id="xxxxxxxxxxxx",
        extension_name="example",
    ).load()
)
```